### PR TITLE
support for base-4.10 (ghc 8.2)

### DIFF
--- a/conduit-audio-lame/conduit-audio-lame.cabal
+++ b/conduit-audio-lame/conduit-audio-lame.cabal
@@ -25,7 +25,7 @@ library
     Data.Conduit.Audio.LAME
     Data.Conduit.Audio.LAME.Binding
   build-depends:
-    base >= 4.6 && < 4.10
+    base >= 4.6 && < 4.11
     , bytestring
     , conduit
     , conduit-audio >= 0.1 && < 0.3

--- a/conduit-audio-samplerate/conduit-audio-samplerate.cabal
+++ b/conduit-audio-samplerate/conduit-audio-samplerate.cabal
@@ -25,7 +25,7 @@ library
     Data.Conduit.Audio.SampleRate
     Data.Conduit.Audio.SampleRate.Binding
   build-depends:
-    base >= 4.6 && < 4.10
+    base >= 4.6 && < 4.11
     , conduit
     , conduit-audio >= 0.1 && < 0.3
     , resourcet

--- a/conduit-audio-sndfile/conduit-audio-sndfile.cabal
+++ b/conduit-audio-sndfile/conduit-audio-sndfile.cabal
@@ -22,7 +22,7 @@ library
   exposed-modules:
     Data.Conduit.Audio.Sndfile
   build-depends:
-    base >= 4.6 && < 4.10
+    base >= 4.6 && < 4.11
     , conduit
     , conduit-audio >= 0.1 && < 0.3
     , hsndfile

--- a/conduit-audio/conduit-audio.cabal
+++ b/conduit-audio/conduit-audio.cabal
@@ -28,7 +28,7 @@ library
   exposed-modules:
     Data.Conduit.Audio
   build-depends:
-    base >= 4.6 && < 4.10
+    base >= 4.6 && < 4.11
     , conduit
     , vector
   hs-source-dirs:       src


### PR DESCRIPTION
Hi!  Thank you for the great libraries :)  I'm trying to get this to work on base-4.10 and GHC 8.2.  However, I'm getting some errs with `c2hs` on 8.2 (and not on 8.0), for some reason...

For `conduit-audio-lame`:

```
Preprocessing library for conduit-audio-lame-0.1.2..
c2hs: Error limit of 20 errors has been reached.
src/Data/Conduit/Audio/LAME/Binding.chs:34: (column 30) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:33: (column 31) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:32: (column 31) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:31: (column 27) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:30: (column 27) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:29: (column 33) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:28: (column 33) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:27: (column 30) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:26: (column 30) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:25: (column 29) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:24: (column 29) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:23: (column 24) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:22: (column 24) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:21: (column 31) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:20: (column 31) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:19: (column 32) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:18: (column 32) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:17: (column 30) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:16: (column 30) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
src/Data/Conduit/Audio/LAME/Binding.chs:12: (column 23) [ERROR]  >>> Missing "out" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: LAME
  C type      : (LAME)
```

and for `conduit-audio-sample-rate`:

```
Preprocessing library for conduit-audio-samplerate-0.1.0.2..
c2hs: Errors during expansion of binding hooks:

src/Data/Conduit/Audio/SampleRate/Binding.chs:58: (column 5) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: State
  C type      : (State)
src/Data/Conduit/Audio/SampleRate/Binding.chs:53: (column 5) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: State
  C type      : (State)
src/Data/Conduit/Audio/SampleRate/Binding.chs:47: (column 5) [ERROR]  >>> Missing "in" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: State
  C type      : (State)
src/Data/Conduit/Audio/SampleRate/Binding.chs:43: (column 8) [ERROR]  >>> Missing "out" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: State
  C type      : (State)
src/Data/Conduit/Audio/SampleRate/Binding.chs:38: (column 8) [ERROR]  >>> Missing "out" marshaller!
  There is no default marshaller for this combination of Haskell and C type:
  Haskell type: State
  C type      : (State)
```

Do you know what might be the issue?

Feel free to close this PR if you would rather take a look at it yourself :)