### PR TITLE
update base upper bound for ghc 8.4.1, and bump minor version numbers

### DIFF
--- a/conduit-audio-ao/conduit-audio-ao.cabal
+++ b/conduit-audio-ao/conduit-audio-ao.cabal
@@ -1,5 +1,5 @@
 name:                 conduit-audio-ao
-version:              0.1
+version:              0.1.1
 author:               Michael Tolly
 maintainer:           miketolly@gmail.com
 category:             Sound
@@ -13,7 +13,7 @@ library
     Data.Conduit.Audio.AO
     Data.Conduit.Audio.AO.Binding
   build-depends:
-    base >= 4.6 && < 4.10
+    base >= 4.6 && < 4.12
     , conduit
     , conduit-audio >= 0.1 && < 0.3
     , resourcet

--- a/conduit-audio-lame/conduit-audio-lame.cabal
+++ b/conduit-audio-lame/conduit-audio-lame.cabal
@@ -1,5 +1,5 @@
 name:                 conduit-audio-lame
-version:              0.1.2.1
+version:              0.1.2.2
 author:               Michael Tolly
 maintainer:           miketolly@gmail.com
 license:              BSD3
@@ -25,7 +25,7 @@ library
     Data.Conduit.Audio.LAME
     Data.Conduit.Audio.LAME.Binding
   build-depends:
-    base >= 4.6 && < 4.11
+    base >= 4.6 && < 4.12
     , bytestring
     , conduit
     , conduit-audio >= 0.1 && < 0.3

--- a/conduit-audio-mpg123/conduit-audio-mpg123.cabal
+++ b/conduit-audio-mpg123/conduit-audio-mpg123.cabal
@@ -1,5 +1,5 @@
 name:                 conduit-audio-mpg123
-version:              0.1
+version:              0.1.1
 author:               Michael Tolly
 maintainer:           miketolly@gmail.com
 license:              BSD3
@@ -15,7 +15,7 @@ library
   exposed-modules:
     Data.Conduit.Audio.Mpg123
   build-depends:
-    base >= 4.6 && < 4.11
+    base >= 4.6 && < 4.12
     , conduit
     , conduit-audio >= 0.1 && < 0.3
     , mpg123-bindings

--- a/conduit-audio-openal/conduit-audio-openal.cabal
+++ b/conduit-audio-openal/conduit-audio-openal.cabal
@@ -1,5 +1,5 @@
 name:                 conduit-audio-openal
-version:              0.1
+version:              0.1.1
 author:               Michael Tolly
 maintainer:           miketolly@gmail.com
 category:             Sound
@@ -10,7 +10,7 @@ library
   exposed-modules:
     Data.Conduit.Audio.OpenAL
   build-depends:
-    base >= 4.7 && < 4.10
+    base >= 4.7 && < 4.12
     , al
     , conduit-audio >= 0.1 && < 0.3
     , resourcet

--- a/conduit-audio-samplerate/conduit-audio-samplerate.cabal
+++ b/conduit-audio-samplerate/conduit-audio-samplerate.cabal
@@ -1,5 +1,5 @@
 name:                 conduit-audio-samplerate
-version:              0.1.0.3
+version:              0.1.0.4
 author:               Michael Tolly
 maintainer:           miketolly@gmail.com
 license:              BSD3
@@ -25,7 +25,7 @@ library
     Data.Conduit.Audio.SampleRate
     Data.Conduit.Audio.SampleRate.Binding
   build-depends:
-    base >= 4.6 && < 4.11
+    base >= 4.6 && < 4.12
     , conduit
     , conduit-audio >= 0.1 && < 0.3
     , resourcet

--- a/conduit-audio-sndfile/conduit-audio-sndfile.cabal
+++ b/conduit-audio-sndfile/conduit-audio-sndfile.cabal
@@ -1,5 +1,5 @@
 name:                 conduit-audio-sndfile
-version:              0.1.2.1
+version:              0.1.2.2
 author:               Michael Tolly
 maintainer:           miketolly@gmail.com
 license:              BSD3
@@ -22,7 +22,7 @@ library
   exposed-modules:
     Data.Conduit.Audio.Sndfile
   build-depends:
-    base >= 4.6 && < 4.11
+    base >= 4.6 && < 4.12
     , conduit
     , conduit-audio >= 0.1 && < 0.3
     , hsndfile

--- a/conduit-audio/conduit-audio.cabal
+++ b/conduit-audio/conduit-audio.cabal
@@ -1,5 +1,5 @@
 name:                 conduit-audio
-version:              0.2.0.3
+version:              0.2.0.4
 author:               Michael Tolly
 maintainer:           miketolly@gmail.com
 license:              BSD3
@@ -28,7 +28,7 @@ library
   exposed-modules:
     Data.Conduit.Audio
   build-depends:
-    base >= 4.6 && < 4.11
+    base >= 4.6 && < 4.12
     , conduit
     , vector
   hs-source-dirs:       src


### PR DESCRIPTION
I haven't tested ao, lame, mp123, or openal since I don't have the libraries,
but the major breaking change is Semigroup => Monoid, so if they don't define
Monoids, they should be fine.